### PR TITLE
Bug: add missing index.js file to the src folder in client

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,16 @@
+import { Provider } from '@urql/preact';
+import { client } from './services/graphqlService';
+import './style';
+import App from './components/app';
+import { AuthProvider } from './context/AuthContext';
+import { NetworkProvider } from './context/NetworkContext';
+
+export default () => (
+  <Provider value={client}>
+    <NetworkProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </NetworkProvider>
+  </Provider>
+);


### PR DESCRIPTION
The index.js file in /client/src was somehow deleted in between the original fork from Guilliem's repo to the previous pull request. I was unable to launch the client app withouth the file, so adding it back in.